### PR TITLE
fix: rename [RecentlyPlayed.items.playedAt]

### DIFF
--- a/typings/player.d.ts
+++ b/typings/player.d.ts
@@ -149,7 +149,7 @@ export interface RecentlyPlayed {
         /** The track which has been played recently. */
         track: Track,
         /** The timestamp when it was played. */
-        playedAt: string
+        played_at: string
     }[];
 }
 


### PR DESCRIPTION
Each item of the interface RecentlyPlayed has the property `playedAt`, which should instead be `played_at`.

https://developer.spotify.com/documentation/web-api/reference/get-recently-played
![image](https://github.com/user-attachments/assets/567ec7ca-b6dd-49d5-a808-47f6952eea5a)